### PR TITLE
Document new config for s3 assume role external ID

### DIFF
--- a/docs/configuration/options.mdx
+++ b/docs/configuration/options.mdx
@@ -420,6 +420,8 @@ imgproxy can process files from Amazon S3 buckets, but this feature is disabled 
 * [`IMGPROXY_S3_ENDPOINT`]: a custom S3 endpoint to being used by imgproxy
 * [`IMGPROXY_S3_MULTI_REGION`]: when `true`, allows using S3 buckets from different regions. Default: `false`
 * [`IMGPROXY_S3_USE_DECRYPTION_CLIENT`]: when `true`, enables client-side decryption. Default: `false`
+* [`IMGPROXY_S3_ASSUME_ROLE_ARN`]: a custom role to assume 
+* [`IMGPROXY_S3_ASSUME_ROLE_EXTERNAL_ID`]: the external ID required to assume a custom role
 
 Check out the [Serving files from S3](../image_sources/amazon_s3.mdx) guide to learn more.
 

--- a/docs/image_sources/amazon_s3.mdx
+++ b/docs/image_sources/amazon_s3.mdx
@@ -13,7 +13,8 @@ imgproxy can process images from S3 buckets. To use this feature, do the followi
 5. _(optional)_ Set the `IMGPROXY_S3_MULTI_REGION` environment variable to be `true`.
 6. _(optional)_ Set the `IMGPROXY_S3_USE_DECRYPTION_CLIENT` environment variable to `true` if your objects are client-side encrypted.
 7. _(optional)_ Specify the AWS IAM Role to Assume with `IMGPROXY_S3_ASSUME_ROLE_ARN`.
-8. Use `s3://%bucket_name/%file_key` as the source image URL.
+8. _(optional)_ Specify the External ID that needs to be passed in along with the AWS IAM Role to Assume with `IMGPROXY_S3_ASSUME_ROLE_EXTERNAL_ID`. This will have no effect if the assume role ARN is not specified.
+9. Use `s3://%bucket_name/%file_key` as the source image URL.
 
 If you need to specify the version of the source object, you can use the query string of the source URL:
 
@@ -56,7 +57,7 @@ aws_secret_access_key = %secret_access_key
 
 #### Cross-Account Access
 
-S3 access credentials may be acquired by assuming a role using STS. To do so specify the IAM Role arn with the `IMGPROXY_S3_ASSUME_ROLE_ARN` environment variable. This approach still requires you to provide initial AWS credentials by using one of the ways described above. The provided credentials role should allow assuming the role with provided ARN.
+S3 access credentials may be acquired by assuming a role using STS. To do so specify the IAM Role arn with the `IMGPROXY_S3_ASSUME_ROLE_ARN` environment variable. Additionally, if you require an external ID to be passed when assuming a role, specify the `IMGPROXY_S3_ASSUME_ROLE_EXTERNAL_ID` environment variable. This approach still requires you to provide initial AWS credentials by using one of the ways described above. The provided credentials role should allow assuming the role with provided ARN.
 
 ## Multi-Region mode
 


### PR DESCRIPTION
Documentation for new configuration on specifying an external ID when assuming a role with S3

Part of https://github.com/imgproxy/imgproxy/issues/1289